### PR TITLE
Add Windows launcher for viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,22 @@ prepare the library for use in your application.
 An HTML-based viewer is available in [`viewer/`](viewer) for reading the Arabic
 whitepaper with a simple search feature. Open `viewer/index.html` in your web
 browser to try it out.
+
+### Windows launcher
+
+For convenience, a small Python script `launch_viewer.py` opens the viewer
+directly in your default browser. Run it with Python 3:
+
+```bash
+python launch_viewer.py
+```
+
+To create a standalone executable on Windows, install
+[PyInstaller](https://pyinstaller.org/) and execute:
+
+```bash
+pyinstaller --onefile launch_viewer.py
+```
+
+This will generate `dist/launch_viewer.exe` which you can double-click to start
+the viewer without needing Python installed.

--- a/launch_viewer.py
+++ b/launch_viewer.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Open the IBADAH whitepaper viewer.
+
+This script opens ``viewer/index.html`` in the default web browser.
+Use it on Windows to quickly launch the interactive whitepaper.
+"""
+from __future__ import annotations
+import webbrowser
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent
+    viewer = root / "viewer" / "index.html"
+    webbrowser.open(viewer.as_uri())
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `launch_viewer.py` to open the interactive whitepaper in the browser
- document how to run the new script and build a standalone exe on Windows

## Testing
- `python -m py_compile $(git ls-files '*.py') launch_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_6851128ac80883259abd67f9e17deb9b